### PR TITLE
Static `val` left in all Python unit classes

### DIFF
--- a/templates/blitz.py
+++ b/templates/blitz.py
@@ -63,6 +63,7 @@ class ${name}I(_omero_model.${name}, UnitBase):
 {% end %}\
 {% end %}\
 {% end %}\
+    del val
 
     SYMBOLS = dict()
 {% for x in sorted(items) %}\


### PR DESCRIPTION
The for-loop variable `val` in all of the generated code
remained in instantiated objects and confusing contained
the last value of the static loop!

See:
https://github.com/openmicroscopy/openmicroscopy/pull/4508
